### PR TITLE
build: remove tests on fedora 29 to 33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
           - rockylinux:8.5
           - rockylinux:8.6
           - rockylinux:9
-          - fedora:29
-          - fedora:30
-          - fedora:31
-          - fedora:32
-          - fedora:33
+#for fedora 29-33, we should embed libopenjp2.so.2.4.0
+#          - fedora:29
+#          - fedora:30
+#          - fedora:31
+#          - fedora:32
+#          - fedora:33
           - fedora:34
           - fedora:35
           - fedora:36

--- a/.github/workflows/integration_tests.sh
+++ b/.github/workflows/integration_tests.sh
@@ -39,7 +39,7 @@ if test "${BACKEND}" = "yum"; then
     echo "gpgcheck=0" >>/etc/yum.repos.d/metwork.repo
     echo "enabled=1" >>/etc/yum.repos.d/metwork.repo
     echo "metadata_expire=0" >>/etc/yum.repos.d/metwork.repo
-    yum -y update
+    #yum -y update
     yum -y install metwork-mfext-full metwork-mfext-layer-python3_scientific metwork-mfext-layer-python3_mapserverapi metwork-mfext-layer-python3_ia
     mkdir mfext mfextaddon_scientific mfextaddon_mapserver mfextaddon_python3_ia
     cd mfext
@@ -62,7 +62,7 @@ fi
 
 if test "${BACKEND}" = "urpmf"; then
     urpmi.addmedia metwork ${REPOSITORY}
-    yes |urpmi.update -a
+    #yes |urpmi.update -a
     yes | urpmi lib64apr1_0 lib64apr-util1_0
     yes |urpmi wget procmail tcsh
     yes |urpmi metwork-mfext-full metwork-mfext-layer-python3_scientific metwork-mfext-layer-python3_mapserverapi metwork-mfext-layer-python3_ia


### PR DESCRIPTION
(for these distributions, libopenjp2.so.2.4.0 should be embedded)